### PR TITLE
Endpoint UAMI

### DIFF
--- a/.github/workflows/deploy-pf-online-endpoint-pipeline.yml
+++ b/.github/workflows/deploy-pf-online-endpoint-pipeline.yml
@@ -15,8 +15,9 @@ permissions:
 env: 
   AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
   AZURE_ML_WORKSPACE: ${{ vars.AZURE_ML_WORKSPACE }}
-  ENDPOINT_NAME: chat-with-patents5
-  ENDPOINT_IDENTITY_ARM_ID: /subscriptions/c3055f19-326c-4ff3-a9f7-4531fd14f73e/resourceGroups/algattik-ai-exploration/providers/Microsoft.ManagedIdentity/userAssignedIdentities/algattiktest
+  ENDPOINT_NAME: chat-with-patents
+  DEPLOYMENT_NAME: blue
+  ENDPOINT_IDENTITY_ARM_ID: ${{ vars.ENDPOINT_IDENTITY_ARM_ID }}
 
 concurrency:
   group: ${{ github.workflow }} # avoid concurrent runs
@@ -47,18 +48,28 @@ jobs:
         az ml online-endpoint update $args
       env:
         # https://learn.microsoft.com/en-us/azure/machine-learning/how-to-access-resources-from-endpoints-managed-identities?view=azureml-api-2&tabs=user-identity-cli#create-an-online-endpoint
-        args: --file deployment/endpoint.yaml --name ${{env.ENDPOINT_NAME}} --set identity.user_assigned_identities[0].resource_id=${{env.ENDPOINT_IDENTITY_ARM_ID}}
-
+        args: >-
+          --file deployment/endpoint.yaml
+          --name ${{env.ENDPOINT_NAME}}
+          --set identity.user_assigned_identities[0].resource_id=${{env.ENDPOINT_IDENTITY_ARM_ID}}
     - name: Get deployment name
-      run: echo "DEPLOYMENT_NAME=$(yq -r .name deployment/deployment.yaml)" >> "$GITHUB_ENV"
-    - name: Update deployment PRT_CONFIG variable
+      run: echo "ENDPOINT_IDENTITY_CLIENT_ID=$(az resource show --id ${{vars.ENDPOINT_IDENTITY_ARM_ID}} --query properties.clientId -o tsv)" >> "$GITHUB_ENV"
+    - name: Configure deployment
       run: |
-        PRT_CONFIG_OVERRIDE=deployment.subscription_id=${{ vars.AZURE_SUBSCRIPTION_ID }},deployment.resource_group=${{ env.AZURE_RESOURCE_GROUP }},deployment.workspace_name=${{ env.AZURE_ML_WORKSPACE }},deployment.endpoint_name=${{ env.ENDPOINT_NAME }},deployment.deployment_name=${{ env.DEPLOYMENT_NAME }}
-        sed -i "s/PRT_CONFIG_OVERRIDE:.*/PRT_CONFIG_OVERRIDE: $PRT_CONFIG_OVERRIDE/g" deployment/deployment.yaml
+        yq -i e '.environment_variables.PRT_CONFIG_OVERRIDE="${{env.PRT_CONFIG_OVERRIDE}}"' deployment/deployment.yaml
+        yq -i e '.environment_variables.AZURE_CLIENT_ID="${{env.ENDPOINT_IDENTITY_CLIENT_ID}}"' deployment/deployment.yaml
+        cat deployment/deployment.yaml
+      env:
+        PRT_CONFIG_OVERRIDE: "deployment.subscription_id=${{ vars.AZURE_SUBSCRIPTION_ID }},deployment.resource_group=${{ env.AZURE_RESOURCE_GROUP }},deployment.workspace_name=${{ env.AZURE_ML_WORKSPACE }},deployment.endpoint_name=${{ env.ENDPOINT_NAME }},deployment.deployment_name=${{ env.DEPLOYMENT_NAME }}"
     - name: Setup deployment
       run: |
-        az ml online-deployment create --file deployment/deployment.yaml --endpoint-name ${{env.ENDPOINT_NAME}} || \
-        az ml online-deployment update --file deployment/deployment.yaml --endpoint-name ${{env.ENDPOINT_NAME}}
+        az ml online-deployment create $args || \
+        az ml online-deployment update $args
+      env:
+        args: >-
+          --name ${{env.DEPLOYMENT_NAME}}
+          --file deployment/deployment.yaml
+          --endpoint-name ${{env.ENDPOINT_NAME}}
     - name: Updating endpoint traffic
       run: az ml online-endpoint update -n ${{env.ENDPOINT_NAME}} --traffic "${{env.DEPLOYMENT_NAME}}=100"
     - name: Check the status of the endpoint

--- a/.github/workflows/deploy-pf-online-endpoint-pipeline.yml
+++ b/.github/workflows/deploy-pf-online-endpoint-pipeline.yml
@@ -15,7 +15,7 @@ permissions:
 env: 
   AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
   AZURE_ML_WORKSPACE: ${{ vars.AZURE_ML_WORKSPACE }}
-  ENDPOINT_NAME: chat-with-patents-endpoint
+  ENDPOINT_NAME: chat-with-patents
   DEPLOYMENT_NAME: blue
   ENDPOINT_IDENTITY_ARM_ID: ${{ vars.ENDPOINT_IDENTITY_ARM_ID }}
 

--- a/.github/workflows/deploy-pf-online-endpoint-pipeline.yml
+++ b/.github/workflows/deploy-pf-online-endpoint-pipeline.yml
@@ -15,7 +15,7 @@ permissions:
 env: 
   AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
   AZURE_ML_WORKSPACE: ${{ vars.AZURE_ML_WORKSPACE }}
-  ENDPOINT_NAME: chat-with-patents
+  ENDPOINT_NAME: chat-with-patents-endpoint
   DEPLOYMENT_NAME: blue
   ENDPOINT_IDENTITY_ARM_ID: ${{ vars.ENDPOINT_IDENTITY_ARM_ID }}
 

--- a/.github/workflows/deploy-pf-online-endpoint-pipeline.yml
+++ b/.github/workflows/deploy-pf-online-endpoint-pipeline.yml
@@ -15,7 +15,8 @@ permissions:
 env: 
   AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
   AZURE_ML_WORKSPACE: ${{ vars.AZURE_ML_WORKSPACE }}
-  ENDPOINT_NAME: chat-with-patents
+  ENDPOINT_NAME: chat-with-patents5
+  ENDPOINT_IDENTITY_ARM_ID: /subscriptions/c3055f19-326c-4ff3-a9f7-4531fd14f73e/resourceGroups/algattik-ai-exploration/providers/Microsoft.ManagedIdentity/userAssignedIdentities/algattiktest
 
 concurrency:
   group: ${{ github.workflow }} # avoid concurrent runs
@@ -42,8 +43,12 @@ jobs:
       run: az configure --defaults group=${{env.AZURE_RESOURCE_GROUP}} workspace=${{env.AZURE_ML_WORKSPACE}}
     - name: Setup endpoint
       run: |
-        az ml online-endpoint create --file deployment/endpoint.yaml --name ${{env.ENDPOINT_NAME}} || \
-        az ml online-endpoint update --file deployment/endpoint.yaml --name ${{env.ENDPOINT_NAME}}
+        az ml online-endpoint create $args || \
+        az ml online-endpoint update $args
+      env:
+        # https://learn.microsoft.com/en-us/azure/machine-learning/how-to-access-resources-from-endpoints-managed-identities?view=azureml-api-2&tabs=user-identity-cli#create-an-online-endpoint
+        args: --file deployment/endpoint.yaml --name ${{env.ENDPOINT_NAME}} --set identity.user_assigned_identities[0].resource_id=${{env.ENDPOINT_IDENTITY_ARM_ID}}
+
     - name: Get deployment name
       run: echo "DEPLOYMENT_NAME=$(yq -r .name deployment/deployment.yaml)" >> "$GITHUB_ENV"
     - name: Update deployment PRT_CONFIG variable

--- a/.github/workflows/run-eval-pf-pipeline.yml
+++ b/.github/workflows/run-eval-pf-pipeline.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - algattik/tmp
   pull_request:
     branches:
       - main

--- a/.github/workflows/run-eval-pf-pipeline.yml
+++ b/.github/workflows/run-eval-pf-pipeline.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - algattik/tmp
   pull_request:
     branches:
       - main

--- a/CI-CD.md
+++ b/CI-CD.md
@@ -77,7 +77,6 @@ Grant the following IAM role assignments to allow the pipeline to deploy models:
 Grant the following IAM role assignments to allow  the pipeline to assign the managed identity to the deployed online endpoint:
 
 - Resource: the managed identity you created for the online endpoint
-
 - Role: [`Managed Identity Operator`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#managed-identity-operator)
 - Identity: the managed identity you created for CD
 
@@ -94,7 +93,6 @@ First role assignment:
 Second role assignment:
 
 - Resource: the Azure Container Registry (ACR) for the Azure ML workspace
-
 - Role: [`AcrPull`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#acrpull)
 - Identity: the managed identity you created for the endpoint
 
@@ -103,7 +101,6 @@ Second role assignment:
 Grant the following IAM role assignments to [allow the endpoint to retrieve secrets](https://aka.ms/pf-deploy-identity):
 
 - Resource: your Azure ML workspace
-
 - Role: `Azure Machine Learning Workspace Connection Secrets Reader`
 - Identity: the managed identity you created for the endpoint
 

--- a/CI-CD.md
+++ b/CI-CD.md
@@ -7,9 +7,9 @@ Deploy the following Azure Resources
 - Azure OpenAI
 - Azure AI Search
 - Azure ML Workspace
-- Two Azure [User-Assigned Managed Identities](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-manage-user-assigned-managed-identities) for CD
-  - One for CD
-  - One for the online endpoint
+- Two Azure [User-Assigned Managed Identities](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-manage-user-assigned-managed-identities):
+  - One for CD (the identity of the GitHub Actions runner deploying model and endpoint)
+  - One for the online endpoint (the identity of the REST endpoint, downloading model assets and connection secrets from Azure ML)
 
 
 ## Configure application federated credentials

--- a/CI-CD.md
+++ b/CI-CD.md
@@ -1,11 +1,16 @@
 # Continuous Integration/Delivery
 
-## Create an application for CD
+## Deploy Azure resources
 
-[Create a Microsoft Entra application and service principal](
-https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Clinux#use-the-azure-login-action-with-openid-connect).
+Deploy the following Azure Resources
 
-You can also create the application as an Azure [User-Assigned Managed Identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp.)
+- Azure OpenAI
+- Azure AI Search
+- Azure ML Workspace
+- Two Azure [User-Assigned Managed Identities](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-manage-user-assigned-managed-identities) for CD
+  - One for CD
+  - One for the online endpoint
+
 
 ## Configure application federated credentials
 
@@ -16,14 +21,6 @@ Create two Federated credentials for your Organization and Repository:
 
 - One with Entity `Branch` and Branch `main`.
 - One with Entity `Pull request`.
-
-## Deploy Azure resources
-
-Deploy the following Azure Resources
-
-- Azure OpenAI
-- Azure AI Search
-- Azure ML Workspace
 
 ## Configure repository action settings
 
@@ -36,13 +33,15 @@ Deploy the following Azure Resources
 
 ### Variables
 
-| Variable name           | Value                                                   | Example                                |
-| ----------------------- | ------------------------------------------------------- | -------------------------------------- |
-| `AISEARCH_ENDPOINT`     | The endpoint for your deployed Azure AI Search instance | `https://mve.search.windows.net`       |
-| `AZURE_CLIENT_ID`       | The client ID of the application                        | `27b4fd5c-ab61-4f78-8338-5706f03d9073` |
-| `AZURE_SUBSCRIPTION_ID` | The subscription ID of Azure resources                  | `c3055f19-326c-4ff3-a9f7-4531fd14f73e` |
-| `AZURE_TENANT_ID`       | The tenant ID of Azure resources                        | `2ac1091e-2d47-4212-9453-0ca0db6c21d7` |
-| `OPENAI_ENDPOINT`       | The endpoint for your deployed Azure OpenAI instance    | `https://mve.openai.azure.com`         |
+| Variable name              | Value                                                        | Example                                                      |
+| -------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `AISEARCH_ENDPOINT`        | The endpoint for your deployed Azure AI Search instance      | `https://mve.search.windows.net`                             |
+| `AZURE_CLIENT_ID`          | The client ID of the managed identity created for CD         | `9b7af88e-e726-48ce-a44d-9dc8c947fc4b`                       |
+| `AZURE_RESOURCE_GROUP`     | The resource group of the Azure ML workspace                 | `promptflow-demo`                                            |
+| `AZURE_SUBSCRIPTION_ID`    | The subscription ID of Azure resources                       | `c3055f19-326c-4ff3-a9f7-4531fd14f73e`                       |
+| `AZURE_TENANT_ID`          | The tenant ID of Azure resources                             | `2ac1091e-2d47-4212-9453-0ca0db6c21d7`                       |
+| `ENDPOINT_IDENTITY_ARM_ID` | The Azure Resource Manager Resource ID of the managed identity created for the online endpoint | `/subscriptions/c3055f19-326c-4ff3-a9f7-4531fd14f73e/resourceGroups/algattik-ai-exploration/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mve-uami-endpoint` |
+| `OPENAI_ENDPOINT`          | The endpoint for your deployed Azure OpenAI instance         | `https://mve.openai.azure.com`                               |
 
 **Hint**: You can create variables in batch from an `.env` file by running the following [GitHub CLI
 command](https://cli.github.com/manual/gh_variable_set) in context of the repository:
@@ -63,28 +62,48 @@ In Azure ML Studio, under `Prompt flow`, in the `Connections` tab, create the fo
 
 The connections are used by the Azure ML endpoint deployed by the pipeline.
 
-## Grant Azure resource access
+## Grant Azure role assignments
 
-Grant the following RBAC role to allow the pipeline to deploy models:
+### Model deployment
 
-- Identity: the application you created for CD
+Grant the following IAM role assignments to allow the pipeline to deploy models:
+
 - Resource: your Azure ML workspace
 - Role: [`AzureML Data Scientist`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#azureml-data-scientist)
+- Identity: the managed identity you created for CD
 
-## Grant Endpoint permissions resource access
+### Managed identity assignment
 
-After the CI/CD pipeline has run a first time, the endpoint will be created, but is missing the permissions to retrieve secrets to authenticate to Azure OpenAI and Azure AI Search.
+Grant the following IAM role assignments to allow  the pipeline to assign the managed identity to the deployed online endpoint:
 
-The pipeline contains a step to invoke the model, which will then fail with an error similar to:
+- Resource: the managed identity you created for the online endpoint
 
-```text
-Access denied to list workspace secret due to invalid authentication. Please assign RBAC role 'Azure Machine Learning Workspace Connection Secrets Reader' to the endpoint for current workspace, and wait for a few minutes to make sure the new role takes effect. More details can be found in https://aka.ms/pf-deploy-identity.
-```
+- Role: [`Managed Identity Operator`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#managed-identity-operator)
+- Identity: the managed identity you created for CD
 
-Grant the following RBAC role to [allow the endpoint to retrieve secrets](https://aka.ms/pf-deploy-identity):
+### Deployment workspace resources
 
-- Identity:  `Managed identity` -> ` Machine Learning online endpoint` -> `chat-with-patents`
+Grant the following IAM role assignments to [allow the endpoint deployment to deploy the container image and artifacts from the workspace](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-troubleshoot-online-endpoints?view=azureml-api-2&tabs=cli#authorization-error).
+
+First role assignment:
+
+- Resource: the storage account for the Azure ML workspace
+- Role: [`Storage blob data reader`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-blob-data-reader)
+- Identity: the managed identity you created for the endpoint
+
+Second role assignment:
+
+- Resource: the Azure Container Registry (ACR) for the Azure ML workspace
+
+- Role: [`AcrPull`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#acrpull)
+- Identity: the managed identity you created for the endpoint
+
+### Endpoint workspace secrets
+
+Grant the following IAM role assignments to [allow the endpoint to retrieve secrets](https://aka.ms/pf-deploy-identity):
+
 - Resource: your Azure ML workspace
-- Role: `Azure Machine Learning Workspace Connection Secrets Reader`
 
-After that, rerun the pipeline.
+- Role: `Azure Machine Learning Workspace Connection Secrets Reader`
+- Identity: the managed identity you created for the endpoint
+

--- a/chat-with-patents/deployment/deployment.yaml
+++ b/chat-with-patents/deployment/deployment.yaml
@@ -1,5 +1,4 @@
 $schema: https://azuremlschemas.azureedge.net/latest/managedOnlineDeployment.schema.json
-name: blue
 endpoint_name: chat-with-patents-7272ff
 model: azureml:chat-with-patents:1
   # You can also specify model files path inline
@@ -31,3 +30,6 @@ environment_variables:
   # For example, if there are 2 flow outputs: "answer", "context", and I only want to have "answer" in the endpoint response, I can set this env variable to '["answer"]'.
   # If you don't set this environment, by default all flow outputs will be included in the endpoint response.
   # PROMPTFLOW_RESPONSE_INCLUDED_FIELDS: '["category", "evidence"]'
+
+  # Managed identity used to access Azure resources
+  AZURE_CLIENT_ID: <client-id>

--- a/chat-with-patents/deployment/deployment.yaml
+++ b/chat-with-patents/deployment/deployment.yaml
@@ -1,8 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/managedOnlineDeployment.schema.json
-endpoint_name: chat-with-patents-7272ff
-model: azureml:chat-with-patents:1
-  # You can also specify model files path inline
-  # path: examples/flows/chat/basic-chat
+name: chat-with-patents # overridden at deployment time
+endpoint_name: chat-with-patents-7272ff # overridden at deployment time
+model: azureml:chat-with-patents:1 # overridden at deployment time
 environment: 
   image: mcr.microsoft.com/azureml/promptflow/promptflow-runtime:latest
   # inference config is used to build a serving container for online deployments

--- a/chat-with-patents/deployment/endpoint.yaml
+++ b/chat-with-patents/deployment/endpoint.yaml
@@ -1,3 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/managedOnlineEndpoint.schema.json
-name: chat-with-patents
 auth_mode: key
+identity:
+  type: user_assigned
+  user_assigned_identities:
+    - resource_id: user_identity_ARM_id_place_holder

--- a/chat-with-patents/deployment/endpoint.yaml
+++ b/chat-with-patents/deployment/endpoint.yaml
@@ -1,4 +1,5 @@
 $schema: https://azuremlschemas.azureedge.net/latest/managedOnlineEndpoint.schema.json
+name: chat-with-patents # overridden at deployment time
 auth_mode: key
 identity:
   type: user_assigned


### PR DESCRIPTION
Deploy a User-Assigned Managed Identity for the promptflow REST endpoint.

Previously, the endpoint had a System-Assigned Managed Identity (default setting) which had the following downsides:
- The first deployment failed, and we must manually assign IAM permissions to the MI before running the pipeline again.
- If the endpoint is deleted and recreated, a new MI is generated and the assignment must be done again

This change has one downside, that with the default setting permissions on Azure ML storage and container registry were automatically granted. With UAMI, these permissions must be manually granted (once) (this is reflected in updates to CI-CD.md).

Deployment tested here: https://github.com/algattik-mve/promptflow-demo/actions/runs/7127028330